### PR TITLE
Update image URL format to use query parameters

### DIFF
--- a/flyo/CardsGrid.vue
+++ b/flyo/CardsGrid.vue
@@ -11,7 +11,7 @@
     >
       <div class="overflow-hidden rounded-2xl bg-slate-100">
         <img
-          :src="`${item.image.source}/filter/900x900`"
+          :src="`${item.image.source}?w=900&h=900`"
           :alt="item.title"
           class="h-56 w-full object-cover transition duration-500 group-hover:scale-105 sm:h-64"
         >


### PR DESCRIPTION
## Summary
Updated the image URL construction in the CardsGrid component to use query parameters instead of path-based filtering for image resizing.

## Key Changes
- Changed image source URL from `/filter/900x900` path format to `?w=900&h=900` query parameter format
- This allows the image service to handle resizing through standard query parameters rather than URL path manipulation

## Implementation Details
The modification updates how images are requested from the image source. The new format using `w` (width) and `h` (height) query parameters is a more standard approach for image APIs and may provide better compatibility with the underlying image service or CDN.

https://claude.ai/code/session_01SYv2rMjNuTfksJhRuvqUaP